### PR TITLE
Fix infinite loop caused by URL loading

### DIFF
--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -20,8 +20,9 @@ extension WebView: View {
         @MainActor
         private func makeEnhancedWKWebView() -> EnhancedWKWebView {
             let webView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
-            parent.applyModifiers(to: webView)
             proxy.setUp(webView)
+            parent.applyModifiers(to: webView)
+            parent.loadsURLAtFirst(to: webView)
             return webView
         }
 

--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -22,7 +22,7 @@ extension WebView: View {
             let webView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
             proxy.setUp(webView)
             parent.applyModifiers(to: webView)
-            parent.loadInitialURL(to: webView)
+            parent.loadInitialURL(in: webView)
             return webView
         }
 

--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -22,7 +22,7 @@ extension WebView: View {
             let webView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
             proxy.setUp(webView)
             parent.applyModifiers(to: webView)
-            parent.loadsURLAtFirst(to: webView)
+            parent.loadInitialURL(to: webView)
             return webView
         }
 

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -106,6 +106,13 @@ public struct WebView {
         webView.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
         webView.allowsLinkPreview = allowsLinkPreview
         webView.isRefreshable = isRefreshable
+    }
+
+    /// Loads the argument URL received during WebView initialization only once.
+    ///
+    /// This must be used after applyModifiers.
+    @MainActor
+    func loadsURLAtFirst(to webView: EnhancedWKWebView) {
         if let url {
             webView.load(URLRequest(url: url))
         }

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -109,7 +109,7 @@ public struct WebView {
     }
 
     @MainActor
-    func loadsURLAtFirst(to webView: EnhancedWKWebView) {
+    func loadInitialURL(to webView: EnhancedWKWebView) {
         if let url {
             webView.load(URLRequest(url: url))
         }

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -108,9 +108,6 @@ public struct WebView {
         webView.isRefreshable = isRefreshable
     }
 
-    /// Loads the argument URL received during WebView initialization only once.
-    ///
-    /// This must be used after applyModifiers.
     @MainActor
     func loadsURLAtFirst(to webView: EnhancedWKWebView) {
         if let url {

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -109,7 +109,7 @@ public struct WebView {
     }
 
     @MainActor
-    func loadInitialURL(to webView: EnhancedWKWebView) {
+    func loadInitialURL(in webView: EnhancedWKWebView) {
         if let initialURL {
             webView.load(URLRequest(url: initialURL))
         }

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -15,7 +15,7 @@ import WebKit
 public struct WebView {
     let configuration: WKWebViewConfiguration
 
-    private let url: URL?
+    private let initialURL: URL?
 
     private var uiDelegate: (any WKUIDelegate)?
     private var navigationDelegate: (any WKNavigationDelegate)?
@@ -29,7 +29,7 @@ public struct WebView {
     ///   - url: The initial URL to load.
     ///   - configuration: The configuration for the new web view.
     public init(url: URL? = nil, configuration: WKWebViewConfiguration = .init()) {
-        self.url = url
+        self.initialURL = url
         self.configuration = configuration
     }
 
@@ -110,8 +110,8 @@ public struct WebView {
 
     @MainActor
     func loadInitialURL(to webView: EnhancedWKWebView) {
-        if let url {
-            webView.load(URLRequest(url: url))
+        if let initialURL {
+            webView.load(URLRequest(url: initialURL))
         }
     }
 }


### PR DESCRIPTION
Loads the argument URL received during WebView initialization only once.

### How to reproduce the issue.


**ContentViewState.swift**

```diff swift
- let requestURL = URL(string: "https://cybozu.github.io/webview-debugger")!
+ let requestURL = URL(string: "https://www.google.com")!
```

**ContentView.swift**

```diff swift
WebViewReader { proxy in
    VStack {
        // ...

-       WebView(configuration: viewState.configuration)
+       WebView(url: viewState.requestURL, configuration: viewState.configuration)
            .uiDelegate(viewState)
            .navigationDelegate(viewState)
            .allowsInspectable(true)
            .allowsBackForwardNavigationGestures(true)
            .allowsLinkPreview(false)
            .refreshable()
            .border(Color.gray)
    }
-   .onAppear {
-       proxy.load(url: viewState.requestURL)
-   }
+   // .onAppear {
+   //     proxy.load(url: viewState.requestURL)
+   // }
}
```