### PR TITLE
Remove unsafeFlags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("StrictConcurrency"),
-                .unsafeFlags(["-Xfrontend", "-enable-actor-data-race-checks"])
+                .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Removed the `unsafeFlags` because it would not allow installation with the tag specification.