### PR TITLE
Fix infinite loop due to `objectWillChange` firing

### DIFF
--- a/Sources/WebUI/SetUpWebViewProxyAction.swift
+++ b/Sources/WebUI/SetUpWebViewProxyAction.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import WebKit
+
+struct SetUpWebViewProxyAction {
+    let action: (WKWebView) -> Void
+
+    func callAsFunction(_ webView: WKWebView) {
+        action(webView)
+    }
+}
+
+private struct SetUpWebViewProxyActionKey: EnvironmentKey {
+    static var defaultValue = SetUpWebViewProxyAction(action: { _ in })
+}
+
+extension EnvironmentValues {
+    var setUpWebViewProxy: SetUpWebViewProxyAction {
+        get { self[SetUpWebViewProxyActionKey.self] }
+        set { self[SetUpWebViewProxyActionKey.self] = newValue }
+    }
+}
+

--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -13,7 +13,7 @@ extension WebView: View {
     }
 
     struct _WebView: ViewRepresentable {
-        @Environment(\.webViewProxy) private var proxy: WebViewProxy
+        @Environment(\.setUpWebViewProxy) private var setUpWebViewProxy
 
         let parent: WebView
 
@@ -21,7 +21,7 @@ extension WebView: View {
         private func makeEnhancedWKWebView() -> EnhancedWKWebView {
             let webView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
             parent.applyModifiers(to: webView)
-            proxy.setUp(webView)
+            setUpWebViewProxy(webView)
             return webView
         }
 

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -140,14 +140,3 @@ public final class WebViewProxy: ObservableObject {
         }
     }
 }
-
-private struct WebViewProxyKey: EnvironmentKey {
-    static let defaultValue = WebViewProxy()
-}
-
-extension EnvironmentValues {
-    var webViewProxy: WebViewProxy {
-        get { self[WebViewProxyKey.self] }
-        set { self[WebViewProxyKey.self] = newValue }
-    }
-}

--- a/Sources/WebUI/WebViewReader.swift
+++ b/Sources/WebUI/WebViewReader.swift
@@ -34,6 +34,6 @@ public struct WebViewReader<Content: View>: View {
     /// The content and behavior of the view.
     public var body: some View {
         content(proxy)
-            .environment(\.webViewProxy, proxy)
+            .environment(\.setUpWebViewProxy, SetUpWebViewProxyAction(action: proxy.setUp))
     }
 }


### PR DESCRIPTION
An infinite loop occurs in the following flow:

1. A web page is loaded.
1. Upon loading, the `@Published var url` in WebViewProxy is updated.
1. `objectWillChange` of `@Environment(\.webViewProxy)` is triggered.
1. `_WebView.updateEnhancedWKWebView` is called.
1. `applyModifiers` is called, returning to step 1.

This issue is resolved by #1 alone, but this PR addresses the underlying cause, which is the handling of WebViewProxy.