### PR TITLE
Add a load method that takes URLRequest as an argument to WebViewProxy.

### DIFF
--- a/Examples/Examples/ContentView.swift
+++ b/Examples/Examples/ContentView.swift
@@ -50,7 +50,7 @@ struct ContentView: View {
                     .border(Color.gray)
             }
             .onAppear {
-                proxy.load(url: viewState.requestURL)
+                proxy.load(request: viewState.request)
             }
         }
         .padding()

--- a/Examples/Examples/ContentViewState.swift
+++ b/Examples/Examples/ContentViewState.swift
@@ -36,7 +36,7 @@ final class ContentViewState: NSObject, ObservableObject {
     @Published var promptInput = ""
 
     let configuration = WKWebViewConfiguration()
-    let requestURL = URL(string: "https://cybozu.github.io/webview-debugger")!
+    let request = URLRequest(url: URL(string: "https://cybozu.github.io/webview-debugger")!)
 
     override init() {
         super.init()
@@ -44,7 +44,7 @@ final class ContentViewState: NSObject, ObservableObject {
     }
 
     private func setCookie(name: String, value: String) {
-        if let domain = requestURL.host(), let cookie = HTTPCookie(properties: [
+        if let domain = request.url?.host(), let cookie = HTTPCookie(properties: [
             HTTPCookiePropertyKey.name: name,
             HTTPCookiePropertyKey.value: value,
             HTTPCookiePropertyKey.domain: domain,

--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -22,7 +22,7 @@ extension WebView: View {
             let webView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
             setUpWebViewProxy(webView)
             parent.applyModifiers(to: webView)
-            parent.loadInitialURL(in: webView)
+            parent.loadInitialRequest(in: webView)
             return webView
         }
 

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -15,7 +15,7 @@ import WebKit
 public struct WebView {
     let configuration: WKWebViewConfiguration
 
-    private let initialURL: URL?
+    private let initialRequest: URLRequest?
 
     private var uiDelegate: (any WKUIDelegate)?
     private var navigationDelegate: (any WKNavigationDelegate)?
@@ -26,10 +26,10 @@ public struct WebView {
 
     /// Creates new WebView.
     /// - Parameters:
-    ///   - url: The initial URL to load.
+    ///   - request: The initial request specifying the URL to load.
     ///   - configuration: The configuration for the new web view.
-    public init(url: URL? = nil, configuration: WKWebViewConfiguration = .init()) {
-        self.initialURL = url
+    public init(request: URLRequest? = nil, configuration: WKWebViewConfiguration = .init()) {
+        self.initialRequest = request
         self.configuration = configuration
     }
 
@@ -109,9 +109,9 @@ public struct WebView {
     }
 
     @MainActor
-    func loadInitialURL(in webView: EnhancedWKWebView) {
-        if let initialURL {
-            webView.load(URLRequest(url: initialURL))
+    func loadInitialRequest(in webView: EnhancedWKWebView) {
+        if let initialRequest {
+            webView.load(initialRequest)
         }
     }
 }

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -83,13 +83,6 @@ public final class WebViewProxy: ObservableObject {
 
     /// Navigates to a requested URL.
     /// - Parameters:
-    ///   - url: The URL to which to navigate.
-    public func load(url: URL) {
-        webView?.load(URLRequest(url: url))
-    }
-
-    /// Navigates to a requested URL.
-    /// - Parameters:
     ///   - request: The request specifying the URL to which to navigate.
     public func load(request: URLRequest) {
         webView?.load(request)

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -88,6 +88,13 @@ public final class WebViewProxy: ObservableObject {
         webView?.load(URLRequest(url: url))
     }
 
+    /// Navigates to a requested URL.
+    /// - Parameters:
+    ///   - request: The request specifying the URL to which to navigate.
+    public func load(request: URLRequest) {
+        webView?.load(request)
+    }
+
     /// Reloads the current webpage.
     public func reload() {
         webView?.reload()

--- a/Tests/WebUITests/Mock.swift
+++ b/Tests/WebUITests/Mock.swift
@@ -2,14 +2,14 @@
 import WebKit
 
 final class WKWebViewMock: EnhancedWKWebView {
-    private(set) var loadedURL: URL?
+    private(set) var loadedRequest: URLRequest?
     private(set) var reloadCalled = false
     private(set) var goBackCalled = false
     private(set) var goForwardCalled = false
     private(set) var javaScriptString: String?
 
     override func load(_ request: URLRequest) -> WKNavigation? {
-        loadedURL = request.url
+        loadedRequest = request
         return nil
     }
 

--- a/Tests/WebUITests/WebViewProxyTests.swift
+++ b/Tests/WebUITests/WebViewProxyTests.swift
@@ -13,6 +13,16 @@ final class WebViewProxyTests: XCTestCase {
     }
 
     @MainActor
+    func test_load_the_specified_URLRequest() {
+        let sut = WebViewProxy()
+        let webViewMock = WKWebViewMock()
+        sut.setUp(webViewMock)
+        let request = URLRequest(url: URL(string: "https://www.example.com")!)
+        sut.load(request: request)
+        XCTAssertEqual(webViewMock.loadedURL, request.url)
+    }
+
+    @MainActor
     func test_reload() {
         let sut = WebViewProxy()
         let webViewMock = WKWebViewMock()

--- a/Tests/WebUITests/WebViewProxyTests.swift
+++ b/Tests/WebUITests/WebViewProxyTests.swift
@@ -3,23 +3,13 @@ import XCTest
 
 final class WebViewProxyTests: XCTestCase {
     @MainActor
-    func test_load_the_specified_URL() {
-        let sut = WebViewProxy()
-        let webViewMock = WKWebViewMock()
-        sut.setUp(webViewMock)
-        let url = URL(string: "https://www.example.com")!
-        sut.load(url: url)
-        XCTAssertEqual(webViewMock.loadedURL, url)
-    }
-
-    @MainActor
     func test_load_the_specified_URLRequest() {
         let sut = WebViewProxy()
         let webViewMock = WKWebViewMock()
         sut.setUp(webViewMock)
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
         sut.load(request: request)
-        XCTAssertEqual(webViewMock.loadedURL, request.url)
+        XCTAssertEqual(webViewMock.loadedRequest, request)
     }
 
     @MainActor

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -53,19 +53,19 @@ final class WebViewTests: XCTestCase {
     }
 
     @MainActor
-    func test_loadInitialURL_do_not_load_URL_if_URL_is_not_specified_in_init() {
+    func test_loadInitialRequest_do_not_load_URL_request_if_request_is_not_specified_in_init() {
         let sut = WebView()
         let webViewMock = WKWebViewMock()
-        sut.loadInitialURL(in: webViewMock)
-        XCTAssertNil(webViewMock.loadedURL)
+        sut.loadInitialRequest(in: webViewMock)
+        XCTAssertNil(webViewMock.loadedRequest)
     }
 
     @MainActor
-    func test_loadInitialURL_load_URL_if_URL_is_specified_in_init() {
-        let url = URL(string: "https://www.example.com")!
-        let sut = WebView(url: url)
+    func test_loadInitialRequest_load_URL_request_if_request_is_specified_in_init() {
+        let request = URLRequest(url: URL(string: "https://www.example.com")!)
+        let sut = WebView(request: request)
         let webViewMock = WKWebViewMock()
-        sut.loadInitialURL(in: webViewMock)
-        XCTAssertEqual(webViewMock.loadedURL, url)
+        sut.loadInitialRequest(in: webViewMock)
+        XCTAssertEqual(webViewMock.loadedRequest, request)
     }
 }


### PR DESCRIPTION
Currently `WebViewProxy` only has `load(url: URL)`.
For `URLRequest`, it is possible to specify cachePolicy and timeoutInterval.