### PR TITLE
Fix unsafe concurrency property

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("StrictConcurrency")
+                .enableUpcomingFeature("StrictConcurrency"),
+                .enableUpcomingFeature("GlobalConcurrency"),
             ]
         ),
         .testTarget(

--- a/Sources/WebUI/SetUpWebViewProxyAction.swift
+++ b/Sources/WebUI/SetUpWebViewProxyAction.swift
@@ -10,7 +10,7 @@ struct SetUpWebViewProxyAction {
 }
 
 private struct SetUpWebViewProxyActionKey: EnvironmentKey {
-    static var defaultValue = SetUpWebViewProxyAction(action: { _ in })
+    static let defaultValue = SetUpWebViewProxyAction(action: { _ in })
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
Static property 'defaultValue' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6