### PR TITLE
Replaced enableUpcomingFeature to enableExperimentalFeature of StrictConcurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,9 @@ let package = Package(
                 .process("Resources/PrivacyInfo.xcprivacy")
             ],
             swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("GlobalConcurrency"),
-                .enableUpcomingFeature("StrictConcurrency"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
`enableUpcomingFeature("StrictConcurrency")` does not work in Swift 5.x.
`enableExperimentalFeature("StrictConcurrency")` works.