### PR TITLE
Fixed to prevent a Strict Concurrency warning

### DIFF
--- a/Sources/WebUI/SetUpWebViewProxyAction.swift
+++ b/Sources/WebUI/SetUpWebViewProxyAction.swift
@@ -2,8 +2,9 @@ import SwiftUI
 import WebKit
 
 struct SetUpWebViewProxyAction {
-    let action: (WKWebView) -> Void
+    let action: @MainActor @Sendable (WKWebView) -> Void
 
+    @MainActor
     func callAsFunction(_ webView: WKWebView) {
         action(webView)
     }

--- a/Sources/WebUI/WebViewReader.swift
+++ b/Sources/WebUI/WebViewReader.swift
@@ -34,6 +34,8 @@ public struct WebViewReader<Content: View>: View {
     /// The content and behavior of the view.
     public var body: some View {
         content(proxy)
-            .environment(\.setUpWebViewProxy, SetUpWebViewProxyAction(action: proxy.setUp))
+            .environment(\.setUpWebViewProxy, SetUpWebViewProxyAction(action: {
+                proxy.setUp($0)
+            }))
     }
 }


### PR DESCRIPTION
The changes in #10 have caused compile-time warnings related to Concurrency.
This PR addresses those warnings.