### PR TITLE
Fix flaky ui test

### DIFF
--- a/Examples/ExamplesUITests/ExamplesUITests.swift
+++ b/Examples/ExamplesUITests/ExamplesUITests.swift
@@ -58,7 +58,9 @@ final class ExamplesUITests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "WebView.uiDelegate(_:)") { _ in
-            app.webViews.buttons["Confirm"].tap()
+            let confirmButton = app.webViews.buttons["Confirm"]
+            XCTAssertTrue(confirmButton.waitForExistence(timeout: 3))
+            confirmButton.tap()
             XCTAssertTrue(app.alerts.staticTexts["Confirm Test"].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()
             XCTAssertTrue(app.alerts.staticTexts["Result: OK"].waitForExistence(timeout: 3))

--- a/Examples/ExamplesUITests/ExamplesUITests.swift
+++ b/Examples/ExamplesUITests/ExamplesUITests.swift
@@ -68,13 +68,17 @@ final class ExamplesUITests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "WebView.init(configuration:)") { _ in
-            app.webViews.buttons["Cookies"].tap()
+            let cookiesButton = app.webViews.buttons["Cookies"]
+            XCTAssertTrue(cookiesButton.waitForExistence(timeout: 3))
+            cookiesButton.tap()
             XCTAssertTrue(app.alerts.staticTexts["SampleKey = SampleValue"].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()
         }
 
         XCTContext.runActivity(named: "WebView.navigationDelegate(_:)") { _ in
-            app.webViews.buttons["sms://"].tap()
+            let smsButton = app.webViews.buttons["sms://"]
+            XCTAssertTrue(smsButton.waitForExistence(timeout: 3))
+            smsButton.tap()
             let expectMessage = "Open this link in external app? sms://"
             XCTAssertTrue(app.alerts.staticTexts[expectMessage].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()

--- a/Examples/ExamplesUITests/ExamplesUITests.swift
+++ b/Examples/ExamplesUITests/ExamplesUITests.swift
@@ -59,7 +59,7 @@ final class ExamplesUITests: XCTestCase {
 
         XCTContext.runActivity(named: "WebView.uiDelegate(_:)") { _ in
             let confirmButton = app.webViews.buttons["Confirm"]
-            XCTAssertTrue(confirmButton.waitForExistence(timeout: 3))
+            XCTAssertTrue(confirmButton.waitForExistence(timeout: 15))
             confirmButton.tap()
             XCTAssertTrue(app.alerts.staticTexts["Confirm Test"].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()

--- a/Examples/ExamplesUITests/ExamplesUITests.swift
+++ b/Examples/ExamplesUITests/ExamplesUITests.swift
@@ -68,17 +68,13 @@ final class ExamplesUITests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "WebView.init(configuration:)") { _ in
-            let cookiesButton = app.webViews.buttons["Cookies"]
-            XCTAssertTrue(cookiesButton.waitForExistence(timeout: 3))
-            cookiesButton.tap()
+            app.webViews.buttons["Cookies"].tap()
             XCTAssertTrue(app.alerts.staticTexts["SampleKey = SampleValue"].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()
         }
 
         XCTContext.runActivity(named: "WebView.navigationDelegate(_:)") { _ in
-            let smsButton = app.webViews.buttons["sms://"]
-            XCTAssertTrue(smsButton.waitForExistence(timeout: 3))
-            smsButton.tap()
+            app.webViews.buttons["sms://"].tap()
             let expectMessage = "Open this link in external app? sms://"
             XCTAssertTrue(app.alerts.staticTexts[expectMessage].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()


### PR DESCRIPTION
It is required to wait a long time after calling `WebViewProxy.clearAll()`.