### PR TITLE
Prevent memory leaks

### DIFF
--- a/Sources/WebUI/WebView+Extension.swift
+++ b/Sources/WebUI/WebView+Extension.swift
@@ -20,7 +20,7 @@ extension WebView: View {
         @MainActor
         private func makeView() -> Remakeable<EnhancedWKWebView> {
             let webView = Remakeable<EnhancedWKWebView> {
-                let wrappedView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration)
+                let wrappedView = EnhancedWKWebView(frame: .zero, configuration: parent.configuration ?? .init())
                 parent.applyModifiers(to: wrappedView)
                 return wrappedView
             }

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -13,12 +13,12 @@ import WebKit
 /// ```
 @available(iOS 16.4, macOS 13.3, *)
 public struct WebView {
-    let configuration: WKWebViewConfiguration
+    weak var configuration: WKWebViewConfiguration?
 
     private let initialRequest: URLRequest?
 
-    private var uiDelegate: (any WKUIDelegate)?
-    private var navigationDelegate: (any WKNavigationDelegate)?
+    private weak var uiDelegate: (any WKUIDelegate)?
+    private weak var navigationDelegate: (any WKNavigationDelegate)?
     private var isInspectable = false
     private var allowsBackForwardNavigationGestures = false
     private var allowsLinkPreview = true
@@ -30,7 +30,7 @@ public struct WebView {
     ///   - request: The initial request specifying the URL to load.
     ///   - configuration: The configuration for the new web view.
     @MainActor
-    public init(request: URLRequest? = nil, configuration: WKWebViewConfiguration = .init()) {
+    public init(request: URLRequest? = nil, configuration: WKWebViewConfiguration? = nil) {
         self.initialRequest = request
         self.configuration = configuration
     }

--- a/Tests/WebUITests/WeakReference.swift
+++ b/Tests/WebUITests/WeakReference.swift
@@ -1,8 +1,0 @@
-final class WeakReference<T> where T : AnyObject {
-    weak var value: T?
-
-    func bypass(_ value: T) -> T {
-        self.value = value
-        return value
-    }
-}

--- a/Tests/WebUITests/WeakReference.swift
+++ b/Tests/WebUITests/WeakReference.swift
@@ -1,0 +1,8 @@
+final class WeakReference<T> where T : AnyObject {
+    weak var value: T?
+
+    func bypass(_ value: T) -> T {
+        self.value = value
+        return value
+    }
+}

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class WebViewTests: XCTestCase {
     @MainActor
     func test_configuration_is_weakly_referenced() {
-        var configuration = WebViewConfigurationMock?.some(.init())
+        var configuration: WebViewConfigurationMock? = .init()
         let sut = WebView(configuration: configuration)
         configuration = nil
         XCTAssertNil(sut.configuration)
@@ -23,7 +23,7 @@ final class WebViewTests: XCTestCase {
     func test_uiDelegate_is_weakly_referenced() {
         let actual = WeakReference<UIDelegateMock>()
         let sut = WebView().uiDelegate(actual.bypass(.init()))
-        var webViewMock = EnhancedWKWebViewMock?.some(.init())
+        var webViewMock: EnhancedWKWebViewMock? = .init()
         sut.applyModifiers(to: webViewMock!)
         webViewMock = nil
         XCTAssertNil(actual.value)
@@ -42,7 +42,7 @@ final class WebViewTests: XCTestCase {
     func test_navigationDelegate_is_weakly_referenced() {
         let actual = WeakReference<NavigationDelegateMock>()
         let sut = WebView().navigationDelegate(actual.bypass(.init()))
-        var webViewMock = EnhancedWKWebViewMock?.some(.init())
+        var webViewMock: EnhancedWKWebViewMock? = .init()
         sut.applyModifiers(to: webViewMock!)
         webViewMock = nil
         XCTAssertNil(actual.value)

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -25,9 +25,6 @@ final class WebViewTests: XCTestCase {
         let actual = weaklyScope(UIDelegateMock()) {
             sut = sut.uiDelegate($0)
         }
-        var webViewMock: EnhancedWKWebViewMock? = .init()
-        sut.applyModifiers(to: webViewMock!)
-        webViewMock = nil
         XCTAssertNil(actual)
     }
 
@@ -46,9 +43,6 @@ final class WebViewTests: XCTestCase {
         let actual = weaklyScope(NavigationDelegateMock()) {
             sut = sut.navigationDelegate($0)
         }
-        var webViewMock: EnhancedWKWebViewMock? = .init()
-        sut.applyModifiers(to: webViewMock!)
-        webViewMock = nil
         XCTAssertNil(actual)
     }
 

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -3,6 +3,14 @@ import XCTest
 
 final class WebViewTests: XCTestCase {
     @MainActor
+    func test_configuration_is_weakly_referenced() {
+        var configuration = WebViewConfigurationMock?.some(.init())
+        let sut = WebView(configuration: configuration)
+        configuration = nil
+        XCTAssertNil(sut.configuration)
+    }
+
+    @MainActor
     func test_applyModifiers_uiDelegate() {
         let uiDelegateMock = UIDelegateMock()
         let sut = WebView().uiDelegate(uiDelegateMock)
@@ -12,12 +20,32 @@ final class WebViewTests: XCTestCase {
     }
 
     @MainActor
+    func test_uiDelegate_is_weakly_referenced() {
+        let actual = WeakReference<UIDelegateMock>()
+        let sut = WebView().uiDelegate(actual.bypass(.init()))
+        var webViewMock = EnhancedWKWebViewMock?.some(.init())
+        sut.applyModifiers(to: webViewMock!)
+        webViewMock = nil
+        XCTAssertNil(actual.value)
+    }
+
+    @MainActor
     func test_applyModifiers_navigationDelegate() {
         let navigationDelegateMock = NavigationDelegateMock()
         let sut = WebView().navigationDelegate(navigationDelegateMock)
         let webViewMock = EnhancedWKWebViewMock()
         sut.applyModifiers(to: webViewMock)
         XCTAssertTrue(navigationDelegateMock === webViewMock.navigationDelegateProxy.delegate)
+    }
+
+    @MainActor
+    func test_navigationDelegate_is_weakly_referenced() {
+        let actual = WeakReference<NavigationDelegateMock>()
+        let sut = WebView().navigationDelegate(actual.bypass(.init()))
+        var webViewMock = EnhancedWKWebViewMock?.some(.init())
+        sut.applyModifiers(to: webViewMock!)
+        webViewMock = nil
+        XCTAssertNil(actual.value)
     }
 
     @MainActor

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -21,12 +21,14 @@ final class WebViewTests: XCTestCase {
 
     @MainActor
     func test_uiDelegate_is_weakly_referenced() {
-        let actual = WeakReference<UIDelegateMock>()
-        let sut = WebView().uiDelegate(actual.bypass(.init()))
+        var sut = WebView()
+        let actual = weaklyScope(UIDelegateMock()) {
+            sut = sut.uiDelegate($0)
+        }
         var webViewMock: EnhancedWKWebViewMock? = .init()
         sut.applyModifiers(to: webViewMock!)
         webViewMock = nil
-        XCTAssertNil(actual.value)
+        XCTAssertNil(actual)
     }
 
     @MainActor
@@ -40,12 +42,14 @@ final class WebViewTests: XCTestCase {
 
     @MainActor
     func test_navigationDelegate_is_weakly_referenced() {
-        let actual = WeakReference<NavigationDelegateMock>()
-        let sut = WebView().navigationDelegate(actual.bypass(.init()))
+        var sut = WebView()
+        let actual = weaklyScope(NavigationDelegateMock()) {
+            sut = sut.navigationDelegate($0)
+        }
         var webViewMock: EnhancedWKWebViewMock? = .init()
         sut.applyModifiers(to: webViewMock!)
         webViewMock = nil
-        XCTAssertNil(actual.value)
+        XCTAssertNil(actual)
     }
 
     @MainActor

--- a/Tests/WebUITests/XCTestCase+Extension.swift
+++ b/Tests/WebUITests/XCTestCase+Extension.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+extension XCTestCase {
+    func weaklyScope<T: AnyObject>(
+        _ instance: @autoclosure () -> T,
+        perform action: (T) -> ()
+    ) -> T? {
+        weak var weakValue = {
+            let value = instance()
+            action(value)
+            return value
+        }()
+        return weakValue
+    }
+}


### PR DESCRIPTION
Since `WKWebViewConfiguration`, `WKUIDelegate`, and `WKNavigationDelegate` are referenced in `WKWebView`, it is better that they are weakly referenced in the `WebView`.
Although no specific problems have been found, I think it will help prevent problems.