### PR TITLE
Added UIScrollViewDelegate modifier to WebView

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,23 +1,24 @@
 {
+  "originHash" : "8d0713f99e85713bcfeca96ea72bc336786c71b9743ac2ffb616f58246fc3003",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -19,6 +19,7 @@ public struct WebView {
 
     private var uiDelegate: (any WKUIDelegate)?
     private var navigationDelegate: (any WKNavigationDelegate)?
+    private var scrollDelegate: (any UIScrollViewDelegate)?
     private var isInspectable = false
     private var allowsBackForwardNavigationGestures = false
     private var allowsLinkPreview = true
@@ -54,6 +55,17 @@ public struct WebView {
     public func navigationDelegate(_ navigationDelegate: any WKNavigationDelegate) -> Self {
         var modified = self
         modified.navigationDelegate = navigationDelegate
+        return modified
+    }
+    
+    /// Sets UIScrollViewDelegate to WebView.
+    /// - Parameters:
+    ///   - scrollDelegate: A type that conforms to the `UIScrollViewDelegate` protocol.
+    ///     You have control over web view behavior when you use a delegate.
+    /// - Returns: WebView that applies the received delegate.
+    public func scrollViewDelegate(_ scrollDelegate: any UIScrollViewDelegate) -> Self {
+        var modified = self
+        modified.scrollDelegate = scrollDelegate
         return modified
     }
 
@@ -114,6 +126,7 @@ public struct WebView {
     func applyModifiers(to webView: EnhancedWKWebView) {
         webView.uiDelegate = uiDelegate
         webView.navigationDelegate = navigationDelegate
+        webView.scrollView.delegate = scrollDelegate
         webView.isInspectable = isInspectable
         webView.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
         webView.allowsLinkPreview = allowsLinkPreview

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -115,6 +115,7 @@ public final class WebViewProxy: ObservableObject {
         webView?.wrappedValue.goForward()
     }
     
+    /// Stops loading the current webpage.
     public func stopLoading() {
         webView?.wrappedValue.stopLoading()
     }

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -114,6 +114,10 @@ public final class WebViewProxy: ObservableObject {
     public func goForward() {
         webView?.wrappedValue.goForward()
     }
+    
+    public func stopLoading() {
+        webView?.wrappedValue.stopLoading()
+    }
 
     /// Evaluates the specified JavaScript string.
     /// - Parameters:

--- a/Tests/WebUITests/Mock.swift
+++ b/Tests/WebUITests/Mock.swift
@@ -7,6 +7,8 @@ final class EnhancedWKWebViewMock: EnhancedWKWebView {
     private(set) var loadedBaseURL: URL?
     private(set) var reloadCalled = false
     private(set) var goBackCalled = false
+    private(set) var stopLoadingCalled = false
+
     private(set) var goForwardCalled = false
     private(set) var javaScriptString: String?
 
@@ -33,6 +35,11 @@ final class EnhancedWKWebViewMock: EnhancedWKWebView {
 
     override func goForward() -> WKNavigation? {
         goForwardCalled = true
+        return nil
+    }
+    
+    override func stopLoading() -> WKNavigation? {
+        stopLoadingCalled = true
         return nil
     }
 

--- a/Tests/WebUITests/WebViewProxyTests.swift
+++ b/Tests/WebUITests/WebViewProxyTests.swift
@@ -60,6 +60,17 @@ struct WebViewProxyTests {
         sut.goForward()
         #expect((webViewMock.wrappedValue as! EnhancedWKWebViewMock).goForwardCalled)
     }
+    
+    @MainActor @Test
+    func stop_loadnig() {
+        let sut = WebViewProxy()
+        let webViewMock = Remakeable {
+            EnhancedWKWebViewMock() as EnhancedWKWebView
+        }
+        sut.setUp(webViewMock)
+        sut.stopLoading()
+        #expect((webViewMock.wrappedValue as! EnhancedWKWebViewMock).stopLoadingCalled)
+    }
 
     @MainActor @Test
     func evaluate_JavaScript() async throws {


### PR DESCRIPTION
I added a modifier to WebView to support UIScrollViewDelegate.  I'm implementing WebUI with a custom toolbar and wanted to ensure the toolbar view hides when the user scrolls down and appears when they scroll up.  This is my first contribution to someone else's project -- hope I got it right!  

Allows the SwiftUI container / caller to set the WKWebView.scrollView.delegate with the modifier scrollViewDelegate(_:).