### PR TITLE
Add `allowsOpaqueDrawing(_:)` modifier

### DIFF
--- a/Sources/WebUI/EnhancedWKWebView.swift
+++ b/Sources/WebUI/EnhancedWKWebView.swift
@@ -42,7 +42,9 @@ class EnhancedWKWebView: WKWebView {
 
     var allowsOpaqueDrawing = true {
         willSet {
+            #if canImport(UIKit)
             isOpaque = newValue
+            #endif
         }
     }
 

--- a/Sources/WebUI/EnhancedWKWebView.swift
+++ b/Sources/WebUI/EnhancedWKWebView.swift
@@ -40,6 +40,12 @@ class EnhancedWKWebView: WKWebView {
         }
     }
 
+    var allowsOpaqueDrawing = true {
+        willSet {
+            isOpaque = newValue
+        }
+    }
+
     var isRefreshable = false {
         willSet {
             if newValue {

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -23,8 +23,8 @@ public struct WebView {
     private var allowsBackForwardNavigationGestures = false
     private var allowsLinkPreview = true
     private var allowsScrollViewBounces = true
-    private var isRefreshable = false
     private var allowsOpaqueDrawing = true
+    private var isRefreshable = false
 
     /// Creates new WebView.
     /// - Parameters:

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -24,6 +24,7 @@ public struct WebView {
     private var allowsLinkPreview = true
     private var allowsScrollViewBounces = true
     private var isRefreshable = false
+    private var isOpaque = true
 
     /// Creates new WebView.
     /// - Parameters:
@@ -110,6 +111,15 @@ public struct WebView {
         return modified
     }
 
+    /// Sets value for isOpaque to WebView.
+    /// - Parameter isOpaque: A Boolean value indicating whether the view fills its frame rectangle with opaque content.
+    /// - Returns: WebView that controls whether users can make the background of the view transparent.
+    public func isOpaque(_ isOpaque: Bool) -> Self {
+        var modified = self
+        modified.isOpaque = isOpaque
+        return modified
+    }
+
     @MainActor
     func applyModifiers(to webView: EnhancedWKWebView) {
         webView.uiDelegate = uiDelegate
@@ -119,6 +129,7 @@ public struct WebView {
         webView.allowsLinkPreview = allowsLinkPreview
         webView.allowsScrollViewBounces = allowsScrollViewBounces
         webView.isRefreshable = isRefreshable
+        webView.isOpaque = isOpaque
     }
 
     @MainActor

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -99,6 +99,15 @@ public struct WebView {
         return modified
     }
 
+    /// Sets value for isOpaque to WebView.
+    /// - Parameter enabled: A Boolean value indicating whether the view fills its frame rectangle with opaque content.
+    /// - Returns: WebView that controls whether users can make the background of the view transparent.
+    public func allowsOpaqueDrawing(_ enabled: Bool) -> Self {
+        var modified = self
+        modified.allowsOpaqueDrawing = enabled
+        return modified
+    }
+
     /// Marks this view as refreshable.
     ///
     /// Applying this modifier to a WebView reloads page contents when users perform an action to refresh.
@@ -108,15 +117,6 @@ public struct WebView {
     public func refreshable() -> Self {
         var modified = self
         modified.isRefreshable = true
-        return modified
-    }
-
-    /// Sets value for isOpaque to WebView.
-    /// - Parameter enabled: A Boolean value indicating whether the view fills its frame rectangle with opaque content.
-    /// - Returns: WebView that controls whether users can make the background of the view transparent.
-    public func allowsOpaqueDrawing(_ enabled: Bool) -> Self {
-        var modified = self
-        modified.allowsOpaqueDrawing = enabled
         return modified
     }
 

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -24,7 +24,7 @@ public struct WebView {
     private var allowsLinkPreview = true
     private var allowsScrollViewBounces = true
     private var isRefreshable = false
-    private var isOpaque = true
+    private var allowsOpaqueDrawing = true
 
     /// Creates new WebView.
     /// - Parameters:
@@ -112,11 +112,11 @@ public struct WebView {
     }
 
     /// Sets value for isOpaque to WebView.
-    /// - Parameter isOpaque: A Boolean value indicating whether the view fills its frame rectangle with opaque content.
+    /// - Parameter enabled: A Boolean value indicating whether the view fills its frame rectangle with opaque content.
     /// - Returns: WebView that controls whether users can make the background of the view transparent.
-    public func isOpaque(_ isOpaque: Bool) -> Self {
+    public func allowsOpaqueDrawing(_ enabled: Bool) -> Self {
         var modified = self
-        modified.isOpaque = isOpaque
+        modified.allowsOpaqueDrawing = enabled
         return modified
     }
 
@@ -128,8 +128,8 @@ public struct WebView {
         webView.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
         webView.allowsLinkPreview = allowsLinkPreview
         webView.allowsScrollViewBounces = allowsScrollViewBounces
+        webView.allowsOpaqueDrawing = allowsOpaqueDrawing
         webView.isRefreshable = isRefreshable
-        webView.isOpaque = isOpaque
     }
 
     @MainActor

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -63,6 +63,14 @@ struct WebViewTests {
     }
 
     @MainActor @Test
+    func test_applyModifiers_isOpeque() {
+        let sut = WebView().isOpaque(false)
+        let webViewMock = EnhancedWKWebViewMock()
+        sut.applyModifiers(to: webViewMock)
+        #expect(!webViewMock.isOpaque)
+    }
+
+    @MainActor @Test
     func test_loadInitialRequest_do_not_load_URL_request_if_request_is_not_specified_in_init() {
         let sut = WebView()
         let webViewMock = EnhancedWKWebViewMock()

--- a/Tests/WebUITests/WebViewTests.swift
+++ b/Tests/WebUITests/WebViewTests.swift
@@ -55,19 +55,19 @@ struct WebViewTests {
     }
 
     @MainActor @Test
+    func test_applyModifiers_allowsOpaqueDrawing() {
+        let sut = WebView().allowsOpaqueDrawing(false)
+        let webViewMock = EnhancedWKWebViewMock()
+        sut.applyModifiers(to: webViewMock)
+        #expect(!webViewMock.allowsOpaqueDrawing)
+    }
+
+    @MainActor @Test
     func test_applyModifiers_isRefreshable() {
         let sut = WebView().refreshable()
         let webViewMock = EnhancedWKWebViewMock()
         sut.applyModifiers(to: webViewMock)
         #expect(webViewMock.isRefreshable)
-    }
-
-    @MainActor @Test
-    func test_applyModifiers_isOpeque() {
-        let sut = WebView().isOpaque(false)
-        let webViewMock = EnhancedWKWebViewMock()
-        sut.applyModifiers(to: webViewMock)
-        #expect(!webViewMock.isOpaque)
     }
 
     @MainActor @Test


### PR DESCRIPTION
Added `allowsOpaqueDrawing(_:)` modifier to make the WebView background transparent.
（WebView の背景を透明にしたいため、 `allowsOpaqueDrawing(_:)` モディファイアを追加しました。）

## Reference

- https://developer.apple.com/documentation/uikit/uiview/isopaque
- https://developer.apple.com/documentation/appkit/nsview/isopaque