### PR TITLE
Make it possible to refer to contentSize via WebViewProxy.

### DIFF
--- a/Sources/WebUI/EnhancedWKWebView.swift
+++ b/Sources/WebUI/EnhancedWKWebView.swift
@@ -1,28 +1,5 @@
 import WebKit
 
-/// This is a workaround for the absence of refresh control in macOS.
-#if canImport(UIKit)
-typealias RefreshControl = UIRefreshControl
-#else
-struct RefreshControl {
-    enum ControlEvent {
-        case valueChanged
-    }
-    func addTarget(_ target: Any?, action: Selector, for controlEvents: ControlEvent) {}
-    func endRefreshing() {}
-}
-private extension WKWebView {
-    struct ScrollView {
-        var bounces = false
-        var refreshControl: RefreshControl? = .init()
-    }
-    var scrollView: ScrollView {
-        get { .init() }
-        set {}
-    }
-}
-#endif
-
 class EnhancedWKWebView: WKWebView {
     override var navigationDelegate: (any WKNavigationDelegate)? {
         get {

--- a/Sources/WebUI/RefreshControl.swift
+++ b/Sources/WebUI/RefreshControl.swift
@@ -12,12 +12,10 @@ struct RefreshControl {
     func addTarget(_ target: Any?, action: Selector, for controlEvents: ControlEvent) {}
     func endRefreshing() {}
 }
-
 extension WKWebView {
-    class ScrollView: NSObject {
+    struct ScrollView {
         var bounces = false
         var refreshControl: RefreshControl? = .init()
-        @objc dynamic var contentSize: CGSize = .zero
     }
 
     var scrollView: ScrollView {

--- a/Sources/WebUI/RefreshControl.swift
+++ b/Sources/WebUI/RefreshControl.swift
@@ -1,0 +1,28 @@
+import WebKit
+
+/// This is a workaround for the absence of refresh control in macOS.
+#if canImport(UIKit)
+typealias RefreshControl = UIRefreshControl
+#else
+struct RefreshControl {
+    enum ControlEvent {
+        case valueChanged
+    }
+
+    func addTarget(_ target: Any?, action: Selector, for controlEvents: ControlEvent) {}
+    func endRefreshing() {}
+}
+
+extension WKWebView {
+    class ScrollView: NSObject {
+        var bounces = false
+        var refreshControl: RefreshControl? = .init()
+        @objc dynamic var contentSize: CGSize = .zero
+    }
+
+    var scrollView: ScrollView {
+        get { .init() }
+        set {}
+    }
+}
+#endif

--- a/Sources/WebUI/RefreshControl.swift
+++ b/Sources/WebUI/RefreshControl.swift
@@ -12,6 +12,7 @@ struct RefreshControl {
     func addTarget(_ target: Any?, action: Selector, for controlEvents: ControlEvent) {}
     func endRefreshing() {}
 }
+
 extension WKWebView {
     struct ScrollView {
         var bounces = false

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -53,7 +53,7 @@ public final class WebViewProxy: ObservableObject {
         }
     }
 
-    private func observe(_ webView: EnhancedWKWebView) {
+    private func observe(_ webView: WKWebView) {
         tasks.forEach { $0.cancel() }
         tasks.removeAll()
 
@@ -88,12 +88,16 @@ public final class WebViewProxy: ObservableObject {
                     self?.canGoForward = value
                 }
             },
+        ]
+        #if canImport(UIKit)
+        tasks.append(
             Task { @MainActor [weak self] in
                 for await value in webView.scrollView.publisher(for: \.contentSize).bufferedValues() {
                     self?._contentSize = value
                 }
-            },
-        ]
+            }
+        )
+        #endif
     }
 
     /// Navigates to a requested URL.

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -29,8 +29,11 @@ public final class WebViewProxy: ObservableObject {
     /// A Boolean value indicating whether there is a forward item in the back-forward list that can be navigated to.
     @Published public private(set) var canGoForward = false
 
+    @Published private var _contentSize: CGSize = .zero
+
     /// The size of the content view.
-    @Published public private(set) var contentSize: CGSize = .zero
+    @available(macOS, unavailable)
+    public var contentSize: CGSize { _contentSize }
 
     private var tasks: [Task<Void, Never>] = []
 
@@ -87,7 +90,7 @@ public final class WebViewProxy: ObservableObject {
             },
             Task { @MainActor [weak self] in
                 for await value in webView.scrollView.publisher(for: \.contentSize).bufferedValues() {
-                    self?.contentSize = value
+                    self?._contentSize = value
                 }
             },
         ]

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -29,6 +29,9 @@ public final class WebViewProxy: ObservableObject {
     /// A Boolean value indicating whether there is a forward item in the back-forward list that can be navigated to.
     @Published public private(set) var canGoForward = false
 
+    /// The size of the content view.
+    @Published public private(set) var contentSize: CGSize = .zero
+
     private var tasks: [Task<Void, Never>] = []
 
     nonisolated init() {}
@@ -47,7 +50,7 @@ public final class WebViewProxy: ObservableObject {
         }
     }
 
-    private func observe(_ webView: WKWebView) {
+    private func observe(_ webView: EnhancedWKWebView) {
         tasks.forEach { $0.cancel() }
         tasks.removeAll()
 
@@ -81,7 +84,12 @@ public final class WebViewProxy: ObservableObject {
                 for await value in webView.publisher(for: \.canGoForward).bufferedValues() {
                     self?.canGoForward = value
                 }
-            }
+            },
+            Task { @MainActor [weak self] in
+                for await value in webView.scrollView.publisher(for: \.contentSize).bufferedValues() {
+                    self?.contentSize = value
+                }
+            },
         ]
     }
 


### PR DESCRIPTION
This PR makes it possible to obtain `contentSize` via `WebViewProxy`.
Similar to `refreshable()`, it uses APIs related to ScrollView, so it works on iOS but not on macOS.

I considered enclosing the provision of `contentSize` with `#if canImport(UIKit)` to make it available only on iOS, or using `@available(macOS, unavailable)` to not provide it on macOS. 
However, considering that the former would make it appear available on macOS in the documentation and the latter cannot be applied to stored properties, I decided to provide it on macOS as well. 

(On macOS, `contentSize` will always return `CGSize.zero`.)