### PR TITLE
Remove PDF Feature

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -118,7 +118,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 183D259B2B566967001FDBDB /* Build configuration list for PBXNativeTarget "Examples" */;
 			buildPhases = (
-				184E6AF92E2B8BB000D08EBE /* Library Swift WebKit Workaround */,
 				183D25882B56695D001FDBDB /* Sources */,
 				183D25892B56695D001FDBDB /* Frameworks */,
 				183D258A2B56695D001FDBDB /* Resources */,
@@ -209,29 +208,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		184E6AF92E2B8BB000D08EBE /* Library Swift WebKit Workaround */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Library Swift WebKit Workaround";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"$PLATFORM_DISPLAY_NAME\" = \"iOS Simulator\" ]; then\n    KEYWORD=\"iOS ${TARGET_DEVICE_OS_VERSION}\"\n    DYLD_FALLBACK_FRAMEWORK_PATH=$(xcrun simctl list devices -v | grep \"$KEYWORD\" | awk -F'[][]' '{print $2}')\n    DYLD_FALLBACK_FRAMEWORK_PATH=\"${DYLD_FALLBACK_FRAMEWORK_PATH}/Contents/Resources/RuntimeRoot/System/Cryptexes/OS/usr/lib/swift/\"\n    LIBRARY_FILE=\"libswiftWebKit.dylib\"\n    ln -sf \"${DYLD_FALLBACK_FRAMEWORK_PATH}/${LIBRARY_FILE}\" \"${BUILT_PRODUCTS_DIR}/${LIBRARY_FILE}\"\n    echo \"👉Created an alias for ${LIBRARY_FILE}\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		183D25882B56695D001FDBDB /* Sources */ = {

--- a/Examples/Examples/ContentView.swift
+++ b/Examples/Examples/ContentView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import WebUI
-import PDFKit
 
 struct ContentView: View {
     @StateObject var viewState = ContentViewState()
@@ -47,28 +46,6 @@ struct ContentView: View {
                     } label: {
                         Label("Load HTML String", systemImage: "doc")
                             .labelStyle(.iconOnly)
-                    }
-
-                    Button {
-                        Task {
-                            viewState.pdf = try! await proxy.contentReader.pdf()
-                        }
-                    } label: {
-                        Label("Take PDF", systemImage: "printer")
-                            .labelStyle(.iconOnly)
-                    }
-                    .accessibilityIdentifier("take_pdf_button")
-
-                    if let data = viewState.pdf,
-                       let pdf = PDFDocument(data: data) {
-                        ShareLink(
-                            item: pdf,
-                            preview: SharePreview(
-                                "PDF Document",
-                                image: pdf.thumbnail ?? Image(systemName: "doc.text")
-                            )
-                        )
-                        .labelStyle(.iconOnly)
                     }
                 }
                 .padding(.vertical, 8)
@@ -125,25 +102,4 @@ private extension WebViewProxy {
 
 #Preview {
     ContentView()
-}
-
-extension PDFDocument: @retroactive Transferable {
-    public static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(exportedContentType: .pdf) { pdf in
-            pdf.dataRepresentation() ?? .init()
-        }
-        .suggestedFileName("Sample.pdf")
-     }
-}
-
-private extension PDFDocument {
-    var thumbnail: Image? {
-        guard let firstPage = page(at: 0) else { return nil }
-        let image = firstPage.thumbnail(of: CGSize(width: 100, height: 100), for: .cropBox)
-        #if canImport(UIKit)
-        return Image(uiImage: image)
-        #elseif canImport(AppKit)
-        return Image(nsImage: image)
-        #endif
-    }
 }

--- a/Examples/Examples/ContentViewState.swift
+++ b/Examples/Examples/ContentViewState.swift
@@ -38,7 +38,6 @@ final class ContentViewState: NSObject, ObservableObject {
     @Published var webDialog: WebDialog?
     @Published var showDialog = false
     @Published var promptInput = ""
-    @Published var pdf: Data?
 
     let configuration = WKWebViewConfiguration()
     let request = URLRequest(url: URL(string: "https://cybozu.github.io/webview-debugger")!)

--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ WebUI is a Swift package that provides WKWebView wrapped by SwiftUI.
 > A native `WebView` for SwiftUI was officially announced by Apple at WWDC 25.
 > However, as its minimum deployment target is iOS 26 and higher, WebUI continues to be an effective solution for projects that must support earlier versions of iOS.
 
-> [!NOTE]
-> Xcode 16.4 has a bug where it cannot resolve the path for `libswiftWebKit.dylib` in the iOS Simulator.  
-> A workaround is required to run apps in the iOS Simulator. Please see the release notes for details.  
-> ref: https://developer.apple.com/forums/thread/785964
->
-> If you do not need the PDF output feature, or if you do not need to verify its functionality in the simulator, please use the `3.2.1-workaround-for-xcode-16-4` branch.
-
 ## Requirements
 
 - Development with Xcode 16.4+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ WebUI is a Swift package that provides WKWebView wrapped by SwiftUI.
 ## Requirements
 
 - Development with Xcode 16.4+
-- Written in Swift 6.0
+- Written in Swift 6.1
 - Compatible with iOS 16.4+
 - Compatible with macOS 13.3+
 
@@ -140,7 +140,7 @@ WebUI is available through [Swift Package Manager](https://github.com/apple/swif
 1. Create `Package.swift` that describes dependencies.
 
    ```swift
-   // swift-tools-version: 6.0
+   // swift-tools-version: 6.1
    import PackageDescription
 
    let package = Package(

--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -29,12 +29,6 @@ public final class WebViewProxy: ObservableObject {
     /// A Boolean value indicating whether there is a forward item in the back-forward list that can be navigated to.
     @Published public private(set) var canGoForward = false
 
-    /// A container for capturing the web view's content.
-    public var contentReader: ContentReader {
-        guard let webView else { fatalError("[WebViewProxy] webView was not set up. This typically indicates a lifecycle issue.") }
-        return .init(webView: webView.wrappedValue)
-    }
-
     @Published private(set) var _contentSize = CGSize.zero
 
     /// The size of the web view’s content.
@@ -189,16 +183,5 @@ public final class WebViewProxy: ObservableObject {
     /// As a side effect, the WKWebView instance will be remade.
     public func clearAll() {
         webView?.remake()
-    }
-
-    /// A container for capturing the web view's content.
-    public struct ContentReader {
-        var webView: WKWebView
-
-        /// Generates PDF data from the web view’s contents asynchronously.
-        @MainActor
-        public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {
-            try await webView.pdf(configuration: configuration)
-        }
     }
 }

--- a/Tests/WebUITests/WebViewProxyTests.swift
+++ b/Tests/WebUITests/WebViewProxyTests.swift
@@ -1,7 +1,6 @@
 @preconcurrency import Combine
 import Foundation
 import Testing
-import PDFKit
 @testable import WebUI
 
 @Suite(.serialized)
@@ -212,18 +211,6 @@ struct WebViewProxyTests {
         #expect((webViewMock.wrappedValue as! EnhancedWKWebViewMock).javaScriptString == "test")
         let result = try #require(actual as? Bool)
         #expect(result)
-    }
-
-    @MainActor @Test
-    func pdf() async throws {
-        let sut = WebViewProxy()
-        let webViewMock = Remakeable {
-            EnhancedWKWebViewMock() as EnhancedWKWebView
-        }
-        sut.setUp(webViewMock)
-
-        let actual = try await sut.contentReader.pdf()
-        #expect(PDFDocument(data: actual) != nil)
     }
 
     @MainActor @Test


### PR DESCRIPTION
We are temporarily removing PDF features for the final stable Xcode 16.x release.
This is a workaround for a bug in Xcode 16.4 that prevents it from locating `libswiftWebKit.dylib` when using WebKit's PDF APIs.