### PR TITLE
Added contentInsetAdjustmentBehavior ViewModifier

### DIFF
--- a/Sources/WebUI/EnhancedWKWebView.swift
+++ b/Sources/WebUI/EnhancedWKWebView.swift
@@ -37,6 +37,12 @@ class EnhancedWKWebView: WKWebView {
         }
     }
 
+    var contentInsetAdjustmentBehavior: ContentInsetAdjustmentBehavior = .automatic {
+        willSet {
+            self.scrollView.contentInsetAdjustmentBehavior = newValue
+        }
+    }
+
     var isRefreshable = false {
         willSet {
             if newValue {

--- a/Sources/WebUI/WebView.swift
+++ b/Sources/WebUI/WebView.swift
@@ -25,6 +25,7 @@ public struct WebView {
     private var allowsScrollViewBounces = true
     private var allowsOpaqueDrawing = true
     private var pageScaleFactor: CGFloat = 1.0
+    private var contentInsetAdjustmentBehavior = ContentInsetAdjustmentBehavior.automatic
     private var isRefreshable = false
 
     /// Creates new WebView.
@@ -120,6 +121,21 @@ public struct WebView {
         return modified
     }
 
+    /// Sets the behavior for determining the adjusted content offsets.
+    /// - Parameter behavior: The behavior for determining the adjusted content offsets.
+    /// - Returns: WebView that applies the content inset adgustment behavior.
+    ///
+    /// This modifier specifies how the safe area insets are used to modify the content area of the scroll view.
+    /// The default value of this property is `ContentInsetAdjustmentBehavior.automatic`.
+    ///
+    /// If you want to use a WebView in full screen on iOS and iPadOS,
+    /// you should specify `ContentInsetAdjustmentBehavior.never` and also apply `SwiftUI.View.ignoresSafeArea()`.
+    public func contentInsetAdjustmentBehavior(_ behavior: ContentInsetAdjustmentBehavior) -> Self {
+        var modified = self
+        modified.contentInsetAdjustmentBehavior = behavior
+        return modified
+    }
+
     /// Marks this view as refreshable.
     /// - Returns: WebView that reloads page contents when users perform an action to refresh.
     ///
@@ -143,6 +159,7 @@ public struct WebView {
         webView.allowsScrollViewBounces = allowsScrollViewBounces
         webView.allowsOpaqueDrawing = allowsOpaqueDrawing
         webView.pageScaleFactor = pageScaleFactor
+        webView.contentInsetAdjustmentBehavior = contentInsetAdjustmentBehavior
         webView.isRefreshable = isRefreshable
     }
 

--- a/Sources/WebUI/WorkaroundForPlatformDifferences.swift
+++ b/Sources/WebUI/WorkaroundForPlatformDifferences.swift
@@ -1,9 +1,17 @@
 import WebKit
 
-/// This is a workaround for the absence of refresh control in macOS.
+/// This is a workaround for APIs that are available in UIKit but not in macOS.
 #if canImport(UIKit)
+public typealias ContentInsetAdjustmentBehavior = UIScrollView.ContentInsetAdjustmentBehavior
 typealias RefreshControl = UIRefreshControl
 #else
+public enum ContentInsetAdjustmentBehavior {
+    case automatic
+    case scrollableAxes
+    case never
+    case always
+}
+
 struct RefreshControl {
     enum ControlEvent {
         case valueChanged
@@ -16,6 +24,7 @@ struct RefreshControl {
 extension WKWebView {
     struct ScrollView {
         var bounces = false
+        var contentInsetAdjustmentBehavior = ContentInsetAdjustmentBehavior.automatic
         var refreshControl: RefreshControl? = .init()
     }
 


### PR DESCRIPTION
close #89 

This provides a means to replicate the same behavior as Safari on iOS.

To make the WebView full screen, set `contentInsetAdjustmentBehavior` to `.never` and also apply `ignoresSafeArea()`.

```swift
WebView(request: URLRequest(url: URL(string: "https://apple.com")!))
    .contentInsetAdjustmentBehavior(.never)
    .ignoresSafeArea()
```

Since the fundamental issue does not exist on macOS, I have implemented a workaround by creating typealiases solely to ensure the code compiles.