### PR TITLE
Use the async version of evaluateJavaScript method.

### DIFF
--- a/Sources/WebUI/WebViewProxy.swift
+++ b/Sources/WebUI/WebViewProxy.swift
@@ -164,18 +164,7 @@ public final class WebViewProxy: ObservableObject {
     /// ```
     @discardableResult
     public func evaluateJavaScript(_ javaScriptString: String) async throws -> Any? {
-        guard let webView else { return nil }
-        return try await withCheckedThrowingContinuation { continuation in
-            webView.wrappedValue.evaluateJavaScript(javaScriptString) { result, error in
-                Task { @MainActor in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: result)
-                    }
-                }
-            }
-        }
+        try await webView?.wrappedValue.evaluateJavaScript(javaScriptString)
     }
 
     /// Clears all properties managed by `WKWebView`.


### PR DESCRIPTION
When attempting to build the WebUI with Xcode 26.4, it was discovered that passing `Any?` as a result within a Task causes a "Sending 'result' risks causing data races" compiler error.

At the time of the initial WebUI implementation (March 2024), the async version of `evaluateJavaScript()` had the following issue:

> Calling a function that returns no value (e.g., `console.log();` or `window.alert();`) was expected to succeed and return `nil`, but it actually triggered a "Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value" crash.

Because of this, we had been using the closure-based callback version of `evaluateJavaScript()`.

However, this issue was fixed by the WebKit team in December 2024, and it now functions as expected in the latest Xcode.
https://github.com/WebKit/WebKit/pull/37519

For these reasons, we are switching to the async version of `evaluateJavaScript()`.