### PR TITLE
Mitigate flaky UI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             -destination "platform=iOS Simulator,arch=arm64,name=iPhone 17,OS=26.2" \
             -maximum-concurrent-test-simulator-destinations 1 \
             -parallel-testing-enabled NO \
+            -retry-tests-on-failure \
             -derivedDataPath DerivedData \
             -resultBundlePath TestResults/ui_test_result_bundle | \
             xcbeautify

--- a/Examples/ExamplesUITests/ExamplesUITests.swift
+++ b/Examples/ExamplesUITests/ExamplesUITests.swift
@@ -8,7 +8,7 @@ final class ExamplesUITests: XCTestCase {
 
         // MARK: WebViewProxy
         XCTContext.runActivity(named: "WebViewProxy.load(request:)") { _ in
-            XCTAssertTrue(app.webViews.staticTexts["History"].waitForExistence(timeout: 15))
+            XCTAssertTrue(app.webViews.staticTexts["History"].waitForExistence(timeout: 30))
         }
 
         XCTContext.runActivity(named: "WebViewProxy.reload()") { _ in
@@ -61,7 +61,7 @@ final class ExamplesUITests: XCTestCase {
         XCTContext.runActivity(named: "WebViewProxy.loadHTMLString()") { _ in
             app.buttons["More"].tap()
             app.buttons["Load HTML String"].tap()
-            XCTAssertTrue(app.webViews.staticTexts["Sample"].waitForExistence(timeout: 15))
+            XCTAssertTrue(app.webViews.staticTexts["Sample"].waitForExistence(timeout: 30))
         }
 
         XCTContext.runActivity(named: "WebViewProxy.clearAll()") { _ in
@@ -73,7 +73,7 @@ final class ExamplesUITests: XCTestCase {
 
         XCTContext.runActivity(named: "WebView.uiDelegate(_:)") { _ in
             let confirmButton = app.webViews.buttons["Confirm"]
-            XCTAssertTrue(confirmButton.waitForExistence(timeout: 15))
+            XCTAssertTrue(confirmButton.waitForExistence(timeout: 30))
             confirmButton.tap()
             XCTAssertTrue(app.alerts.staticTexts["Confirm Test"].waitForExistence(timeout: 3))
             app.alerts.buttons["OK"].tap()


### PR DESCRIPTION
Bumped WebView load timeouts from 15s to 30s and enabled -retry-tests-on-failure for xcodebuild.